### PR TITLE
Add basic comments support to the AST

### DIFF
--- a/pyjsparser/std_nodes.py
+++ b/pyjsparser/std_nodes.py
@@ -451,7 +451,6 @@ class BaseNode:
     def __setitem__(self, key, value):
         setattr(self, key, value)
 
-
 class Node(BaseNode):
     pass
 


### PR DESCRIPTION
Cf #14 

Follows the Recast comment-attachment structure[0], though only implements a small subset in a straightforwardly hacky manner, and does not come close to implementing the entire comment-attachment structure or algorithm:

* comments preceding (some) nodes are extracted and set on the
  `comments` key of the host node
* does not extract the location
* only does leading comments (I don't think it'll mis-attach trailing
  comments but that's not impossible)
* may not work for all node types
* the comments key may be missing entirely
* uses esprima's type (Block/Line) rather than Babel's

[0] dev's reasoning about some comments being ambiguous in Esprima's structure/extension makes sense to me: https://github.com/jquery/esprima/issues/1024#issuecomment-74179681 https://github.com/benjamn/recast/issues/159#issuecomment-76054246